### PR TITLE
feat: enforce where call before ex, exs after oeq in OnFun

### DIFF
--- a/brief-common/pom.xml
+++ b/brief-common/pom.xml
@@ -61,6 +61,18 @@
             <version>2.8.6</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/brief-core/src/main/java/com/javaoffers/brief/modelhelper/fun/crud/OnFun.java
+++ b/brief-core/src/main/java/com/javaoffers/brief/modelhelper/fun/crud/OnFun.java
@@ -11,8 +11,7 @@ import com.javaoffers.brief.modelhelper.fun.StreamingFun;
  */
 public interface OnFun<M1, M2, V, R extends OnFun<M1, M2, V, R> > extends
         SmartOnFun<M1, M2, GetterFun<M1, Object>, GetterFun<M2, Object>, V, R >,
-        StreamingFun<M1>,
-        ExecutFun<M1> {
+        StreamingFun<M1> {
 
 
 }

--- a/brief-core/src/main/java/com/javaoffers/brief/modelhelper/fun/crud/impl/OnFunImpl.java
+++ b/brief-core/src/main/java/com/javaoffers/brief/modelhelper/fun/crud/impl/OnFunImpl.java
@@ -48,15 +48,7 @@ public class OnFunImpl<M1, M2, V> implements OnFun<M1,M2,V,OnFunImpl<M1, M2, V>>
         this.m1Class = m1Class;
     }
 
-    @Override
-    public M1 ex() {
-        return whereSelectFun.ex();
-    }
 
-    @Override
-    public List<M1> exs() {
-        return whereSelectFun.exs();
-    }
 
     @Override
     public OnFunImpl<M1, M2, V> oeq(GetterFun<M1, Object> col, GetterFun<M2, Object> col2) {

--- a/brief-core/src/test/java/com/javaoffers/brief/modelhelper/fun/crud/OnFunTest.java
+++ b/brief-core/src/test/java/com/javaoffers/brief/modelhelper/fun/crud/OnFunTest.java
@@ -1,0 +1,60 @@
+package com.javaoffers.brief.modelhelper.fun.crud;
+
+import com.javaoffers.brief.modelhelper.fun.ExecutFun;
+import com.javaoffers.brief.modelhelper.fun.GetterFun;
+import com.javaoffers.brief.modelhelper.fun.crud.impl.OnFunImpl;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OnFunTest {
+
+    @Test
+    public void testOnFunInterfaceInheritance() {
+        assertFalse(ExecutFun.class.isAssignableFrom(OnFun.class),
+            "OnFun should NOT extend ExecutFun");
+    }
+    
+    @Test
+    public void testOnFunImplDoesNotHaveExMethods() {
+        Class<OnFunImpl> onFunImplClass = OnFunImpl.class;
+        
+        assertFalse(ExecutFun.class.isAssignableFrom(onFunImplClass),
+            "OnFunImpl should NOT implement ExecutFun");
+    }
+    
+    @Test
+    public void testOnFunHasRequiredMethods() {
+        Class<OnFun> onFunClass = OnFun.class;
+        
+        try {
+            onFunClass.getMethod("oeq", GetterFun.class, GetterFun.class);
+            onFunClass.getMethod("where");
+            onFunClass.getMethod("stream", Consumer.class);
+
+            assertTrue(true, "OnFun should have required methods");
+        } catch (NoSuchMethodException e) {
+            fail("OnFun should have required methods: " + e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testOnFunDoesNotHaveExMethods() {
+        Class<OnFun> onFunClass = OnFun.class;
+        
+        try {
+            onFunClass.getMethod("ex");
+            fail("OnFun should NOT have ex() method");
+        } catch (NoSuchMethodException e) {
+            assertTrue(true, "OnFun should NOT have ex() method");
+        }
+        
+        try {
+            onFunClass.getMethod("exs");
+            fail("OnFun should NOT have exs() method");
+        } catch (NoSuchMethodException e) {
+            assertTrue(true, "OnFun should NOT have exs() method");
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Prevent direct `ex()`/`exs()` calls after `oeq()` to avoid accidental full-table operations.

## The Issue associated with the Pull Request
Current API allows `oeq().ex()` pattern which bypasses WHERE condition safety checks.

## Brief changelog OR 
- Remove `ExecutFun` inheritance from `OnFun` interface
- Remove `ex()`/`exs()` methods from `OnFunImpl` class
- Now requires `where()` before `ex()`/`exs()` after `oeq()`

## Verifying this change
- `oeq().ex()` should fail at compile time
- `oeq().where().ex()` should work correctly
- Existing sample code continues to work